### PR TITLE
Add the ability to choose `kubectl` version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM alpine:3
 
 RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh py-pip"]
 
-RUN ["/bin/sh", "-c", "apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing kubectl"]
-
 RUN ["/bin/sh", "-c", "pip3 install -U awscli"]
 
 COPY ["src", "/src/"]

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Inputs configure Terraform GitHub Actions to perform different actions.
 
 | Input Name                          | Description                                                | Required |
 |:------------------------------------|:-----------------------------------------------------------|:--------:|
+| kubectl_version                     | The kubectl version to use. If not set, will default to `latest`.   | `No`    |
 | tf_actions_subcommand               | The Terraform/Terragrunt  subcommand to execute.           | `Yes`    |
 | tf_actions_binary                   | The binary to run the commands with                        | `No`     |
 | tf_actions_version                  | The Terraform version to install and execute. If set to `latest`, the latest stable version will be used. | `Yes` |

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ branding:
   icon: 'cloud'
   color: 'purple'
 inputs:
+  kubectl_version:
+    description: 'kubectl version'
+    default: 'latest'
   tf_actions_subcommand:
     description: 'Terraform or Terragrunt subcommand to execute.'
     required: true

--- a/src/main.sh
+++ b/src/main.sh
@@ -24,6 +24,13 @@ function parseInputs {
     exit 1
   fi
 
+  if [ "${INPUT_KUBECTL_VERSION}" != "" ]; then
+    kubectlVersion=${INPUT_KUBECTL_VERSION}
+  else
+    echo "Input kubectl_version cannot be empty"
+    exit 1
+  fi
+
   if [ "${INPUT_TG_ACTIONS_VERSION}" != "" ]; then
     tgVersion=${INPUT_TG_ACTIONS_VERSION}
   else
@@ -115,6 +122,20 @@ function installTerraform {
   echo "Successfully unzipped Terraform v${tfVersion}"
 }
 
+function installKubectl {
+  if [[ "${kubectlVersion}" == "latest" ]]; then
+    echo "Checking the latest version of kubectl"
+    kubectlUrl=https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+  else
+    echo "Checking version ${kubectlVersion} of kubectl"
+    kubectlUrl=https://storage.googleapis.com/kubernetes-release/release/${kubectlVersion}/bin/linux/amd64/kubectl
+  fi
+
+  curl -LO ${kubectlUrl}
+  chmod +x ./kubectl
+  mv ./kubectl /usr/local/bin/kubectl
+}
+
 function installTerragrunt {
   if [[ "${tgVersion}" == "latest" ]]; then
     echo "Checking the latest version of Terragrunt"
@@ -179,10 +200,12 @@ function main {
       terragruntValidate ${*}
       ;;
     plan)
+      installKubectl
       installTerragrunt
       terragruntPlan ${*}
       ;;
     apply)
+      installKubectl
       installTerragrunt
       terragruntApply ${*}
       ;;


### PR DESCRIPTION
Since the release of `Kubernetes 1.24`, there is some incompatibility between `kubectl client 1.24` and `Kubernetes 1.22.4` (which we currently use).

This Github Actions always install the latest version (`1.24` for now).
We need a way to specify `kubectl` version we need.

As `kubectl` is installed on build time, ideally we should have a way to specify this version at build time (like with `docker build --build-arg KUBECTL_VERSION=v1.22.4)`. Unfortunatly, Github Actions seems not to support such a feature (only `--arg`, not `--build-arg`).

==> I removed the `kubectl` installation from Dockerfile, and moved it in  `main.sh`.
The choice of the `kubectl` version is done with `kubectl_version` argument in Github Workflow (see README.md).